### PR TITLE
Get CSS Rules once

### DIFF
--- a/packages/codelift/components/Store/TailwindRule.ts
+++ b/packages/codelift/components/Store/TailwindRule.ts
@@ -1,4 +1,4 @@
-import { getEnv, getRoot, types } from "mobx-state-tree";
+import { getRoot, types } from "mobx-state-tree";
 
 import { classNameGroups } from "./classNameGroups";
 
@@ -27,13 +27,13 @@ export const TailwindRule = types
     },
 
     get isApplied() {
-      const { target } = getEnv(self).parent;
+      const { target } = getRoot(self);
 
       return target.hasRule(this);
     },
 
     get isMatching() {
-      const { query } = getEnv(self).parent;
+      const { query } = getRoot(self);
 
       if (!query) {
         return true;


### PR DESCRIPTION
Because CRA reloads, re-looking up CSS rules is slow and hinders the DX.

A hard-refresh solves this, but if there's a real need to refresh styles, it can possibly be done off the main thread (maybe not since it can't be serialized), _or_ there's a `↺` button to reload them.