### PR TITLE
SecurityError: Permission denied to access property "scrollX" on…

### DIFF
--- a/packages/codelift/components/App/index.tsx
+++ b/packages/codelift/components/App/index.tsx
@@ -41,7 +41,7 @@ export const App: FunctionComponent = observer(() => {
     <Provider value={client}>
       {store.isOpen && <Selector />}
 
-      <Grid gridTemplateColumns={store.root ? "16rem 1fr 16rem" : "16rem 1fr"}>
+      <Grid gridTemplateColumns="16rem 1fr 16rem">
         <Sidebar>
           {store.root ? (
             <TreeInspector />
@@ -71,11 +71,9 @@ export const App: FunctionComponent = observer(() => {
           />
         </Box>
 
-        {store.root ? (
-          <Sidebar>
-            <CSSInspector />
-          </Sidebar>
-        ) : null}
+        <Sidebar>
+          <CSSInspector />
+        </Sidebar>
       </Grid>
     </Provider>
   );

--- a/packages/codelift/components/Store/index.ts
+++ b/packages/codelift/components/Store/index.ts
@@ -78,6 +78,21 @@ export const Store = types
           ({ group = "Other " }) => group
         )
       );
+    },
+
+    get root() {
+      if (!self.document) {
+        return null;
+      }
+
+      return (
+        // CRA
+        self.document.querySelector("#root") ||
+        // Next.js
+        self.document.querySelector("#__next") ||
+        // Whatever
+        self.document.querySelector("body")
+      );
     }
   }))
   .actions(self => ({
@@ -110,14 +125,6 @@ export const Store = types
         return;
       }
 
-      self.root =
-        // CRA
-        self.document.querySelector("#root") ||
-        // Next.js
-        self.document.querySelector("#__next") ||
-        // Whatever
-        self.document.querySelector("body");
-
       const { selector } = self.target;
 
       const element = selector
@@ -136,7 +143,14 @@ export const Store = types
       self.contentWindow.removeEventListener("keydown", this.handleKeyPress);
       self.contentWindow.addEventListener("keydown", this.handleKeyPress);
 
+      self.contentWindow.addEventListener("unload", this.handleFrameUnload);
+
       this.initCSSRules();
+    },
+
+    handleFrameUnload() {
+      self.contentWindow = null;
+      self.document = null;
     },
 
     handleKeyPress(event: KeyboardEvent) {


### PR DESCRIPTION
When CRA reloads & the app tries to render again, there's a security warning because the window is probably `about:blank`:

> <img width="1045" alt="Screen Shot 2019-12-03 at 11 32 14 PM" src="https://user-images.githubusercontent.com/15182/70122347-52625b00-1625-11ea-8d7a-09a2e87737f0.png">

The fix could be listening for `window.onunload` and removing `store.contentWindow` or `store.root`, so that `Selector` doesn't try to draw via `React.createPortal`.