### PR TITLE
Listen for Next.js HMR changes

### DIFF
--- a/packages/codelift/components/CSSInspector/Rule.tsx
+++ b/packages/codelift/components/CSSInspector/Rule.tsx
@@ -29,8 +29,8 @@ export const Rule: FunctionComponent<RuleProps> = observer(({ rule }) => {
           className: $className
           fileName: $fileName
           lineNumber: $lineNumber
-          )
-        }
+        )
+      }
   `);
 
   if (res.error) {
@@ -47,7 +47,12 @@ export const Rule: FunctionComponent<RuleProps> = observer(({ rule }) => {
     const { debugSource } = target;
 
     if (!debugSource) {
-      console.error("Selected element is missing _debugSource property");
+      const error = new Error(
+        "Selected element is missing _debugSource property"
+      );
+
+      console.error(error, target);
+      throw error;
     }
 
     target.applyRule(rule);

--- a/packages/codelift/components/Store/Target.ts
+++ b/packages/codelift/components/Store/Target.ts
@@ -57,15 +57,21 @@ export const Target = types
       const selectors = [];
 
       while (element) {
+        const nthChild = element.parentNode
+          ? [...element.parentNode.childNodes]
+              .filter(node => node.nodeType === 1)
+              .indexOf(element) + 1
+          : null;
+        const { id, tagName } = element;
+
         selectors.unshift(
           [
-            element.tagName.toLowerCase(),
-            element.className.split(" ").join(".")
+            tagName.toLowerCase(),
+            id && `#${element.id}`,
+            !id && nthChild && `:nth-child(${nthChild})`
           ]
             .filter(Boolean)
-            .join(".")
-            .split(":")
-            .join("\\:")
+            .join("")
         );
 
         element = element.parentElement;
@@ -114,6 +120,8 @@ export const Target = types
     set(element: HTMLElement) {
       self.classNames.replace([...element.classList]);
       self.element = element;
+
+      console.log(self.selector);
     },
 
     unlock() {

--- a/packages/codelift/components/Store/Target.ts
+++ b/packages/codelift/components/Store/Target.ts
@@ -1,4 +1,3 @@
-import unique from "unique-selector";
 import { Instance, types } from "mobx-state-tree";
 
 import { TailwindRule } from "./TailwindRule";
@@ -55,9 +54,24 @@ export const Target = types
         return null;
       }
 
-      return unique(element, {
-        selectorTypes: ["ID", "Tag", "NthChild"]
-      });
+      const selectors = [];
+
+      while (element) {
+        selectors.unshift(
+          [
+            element.tagName.toLowerCase(),
+            element.className.split(" ").join(".")
+          ]
+            .filter(Boolean)
+            .join(".")
+            .split(":")
+            .join("\\:")
+        );
+
+        element = element.parentElement;
+      }
+
+      return selectors.join(" > ");
     }
   }))
   .actions(self => ({

--- a/packages/codelift/components/Store/index.ts
+++ b/packages/codelift/components/Store/index.ts
@@ -125,18 +125,6 @@ export const Store = types
         return;
       }
 
-      const { selector } = self.target;
-
-      const element = selector
-        ? (self.document.querySelector(selector) as HTMLElement)
-        : null;
-
-      if (element) {
-        self.target.set(element);
-      } else {
-        self.target.unset();
-      }
-
       window.removeEventListener("keydown", this.handleKeyPress);
       window.addEventListener("keydown", this.handleKeyPress);
 
@@ -146,6 +134,7 @@ export const Store = types
       self.contentWindow.addEventListener("unload", this.handleFrameUnload);
 
       this.initCSSRules();
+      this.reselectTarget();
     },
 
     handleFrameUnload() {
@@ -253,6 +242,22 @@ export const Store = types
 
     open() {
       self.isOpen = true;
+    },
+
+    reselectTarget() {
+      if (self.document) {
+        const { selector } = self.target;
+
+        if (selector) {
+          const element = self.document.querySelector(selector) as HTMLElement;
+
+          if (element) {
+            return self.target.set(element);
+          }
+        }
+      }
+
+      self.target.unset();
     },
 
     resetQuery() {

--- a/packages/codelift/components/Store/index.ts
+++ b/packages/codelift/components/Store/index.ts
@@ -114,6 +114,8 @@ export const Store = types
       document.domain = "localhost";
 
       self.contentWindow = iframe.contentWindow;
+      // @ts-ignore
+      self.contentWindow["__CODELIFT__"] = self;
 
       try {
         self.document = iframe.contentWindow.document;
@@ -173,6 +175,16 @@ export const Store = types
 
           return this.close();
         }
+      }
+    },
+
+    handleStatus(status: string) {
+      if (
+        status === "idle" &&
+        self.document &&
+        !self.document.contains(self.target.element)
+      ) {
+        this.reselectTarget();
       }
     },
 

--- a/packages/codelift/package.json
+++ b/packages/codelift/package.json
@@ -34,7 +34,6 @@
     "open": "^7.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "unique-selector": "^0.4.1",
     "urql": "^1.6.3",
     "wait-for-localhost": "^3.2.0"
   },

--- a/packages/codelift/register.dev.js
+++ b/packages/codelift/register.dev.js
@@ -1,2 +1,8 @@
 // Allow access from GUI on another port
 document.domain = window.location.hostname;
+
+if (module.hot) {
+  module.hot.addStatusHandler(status => {
+    window["__CODELIFT__"].handleStatus(status);
+  });
+}

--- a/packages/codelift/types/unique-selector.d.ts
+++ b/packages/codelift/types/unique-selector.d.ts
@@ -1,1 +1,0 @@
-declare module "unique-selector";

--- a/yarn.lock
+++ b/yarn.lock
@@ -7147,11 +7147,6 @@ unique-filename@^1.1.1:
   dependencies:
     unique-slug "^2.0.0"
 
-unique-selector@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/unique-selector/-/unique-selector-0.4.1.tgz#f14e0f0e3b8fb3667c8245463c3ffe237442b0ac"
-  integrity sha512-7dLxUE1Wu89fpruo7DAH2k+7UcGSZBnEiwjvlPX5p0LuoJkVIgoaR/5YRFjwmQnVq7ZK0ankCdLRx4mRqd6oOQ==
-
 unique-slug@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"


### PR DESCRIPTION
Because Next.js does HMR and not a full reload, we need a way to listen for changes to the DOM:

> https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver

We can listen to the selected/targeted element when it changes & refresh those nodes (#32), or refresh the entire tree since we don't know _what_ was changed.