### PR TITLE
Have both a Targeted & Selected

### DIFF
--- a/packages/codelift/components/App/index.tsx
+++ b/packages/codelift/components/App/index.tsx
@@ -39,7 +39,7 @@ export const App: FunctionComponent = observer(() => {
 
   return (
     <Provider value={client}>
-      {store.isOpen && <Selector />}
+      {store.isOpen && <Selector node={store.selected} />}
 
       <Grid
         gridTemplateColumns={`${store.isOpen ? "16rem" : 0} 1fr ${

--- a/packages/codelift/components/App/index.tsx
+++ b/packages/codelift/components/App/index.tsx
@@ -41,7 +41,12 @@ export const App: FunctionComponent = observer(() => {
     <Provider value={client}>
       {store.isOpen && <Selector />}
 
-      <Grid gridTemplateColumns="16rem 1fr 16rem">
+      <Grid
+        gridTemplateColumns={`${store.isOpen ? "16rem" : 0} 1fr ${
+          store.isOpen ? "16rem" : 0
+        }`}
+        style={{ transition: "all 200ms ease-in-out" }}
+      >
         <Sidebar>
           {store.root ? (
             <TreeInspector />

--- a/packages/codelift/components/App/index.tsx
+++ b/packages/codelift/components/App/index.tsx
@@ -62,7 +62,7 @@ export const App: FunctionComponent = observer(() => {
           )}
         </Sidebar>
 
-        <Box as="main" boxShadow="lg" height="100vh" overflow="auto">
+        <Box as="main" boxShadow="lg" height="100vh" overflow="auto" zIndex={1}>
           <iframe
             onLoad={store.handleFrameLoad}
             src={`http://localhost:3000${path}`}

--- a/packages/codelift/components/CSSInspector/Rule.tsx
+++ b/packages/codelift/components/CSSInspector/Rule.tsx
@@ -40,22 +40,22 @@ export const Rule: FunctionComponent<RuleProps> = observer(({ rule }) => {
   }
 
   const store = useStore();
-  const { target } = store;
+  const { selected } = store;
   const toggled = false;
   const toggleRule = (rule: Instance<typeof TailwindRule>) => {
     const { className } = rule;
-    const { debugSource } = target;
+    const { debugSource } = selected;
 
     if (!debugSource) {
       const error = new Error(
         "Selected element is missing _debugSource property"
       );
 
-      console.error(error, target);
+      console.error(error, selected);
       throw error;
     }
 
-    target.applyRule(rule);
+    selected.applyRule(rule);
     store.resetQuery();
 
     toggleClassName({ ...debugSource, className });
@@ -69,8 +69,8 @@ export const Rule: FunctionComponent<RuleProps> = observer(({ rule }) => {
       fontSize="xs"
       textDecoration={rule.isApplied && toggled ? "line-through" : undefined}
       onClick={() => toggleRule(rule)}
-      onMouseEnter={() => target.previewRule(rule)}
-      onMouseLeave={() => target.cancelRule(rule)}
+      onMouseEnter={() => selected.previewRule(rule)}
+      onMouseLeave={() => selected.cancelRule(rule)}
       paddingX="2"
       paddingY="1"
       // @ts-ignore

--- a/packages/codelift/components/CSSInspector/index.tsx
+++ b/packages/codelift/components/CSSInspector/index.tsx
@@ -20,13 +20,13 @@ import { GroupedRules } from "./GroupedRules";
 export const CSSInspector: FunctionComponent = observer(() => {
   const store = useStore();
   const searchRef = useRef<HTMLInputElement>(null);
-  const className = store.target.classNames.join(" ");
+  const className = store.selected.classNames.join(" ");
 
   useEffect(() => {
-    if (store.target.isLocked && searchRef.current) {
+    if (searchRef.current) {
       searchRef.current.focus();
     }
-  }, [className, store.target.isLocked]);
+  }, [className]);
 
   return (
     <>

--- a/packages/codelift/components/CSSInspector/index.tsx
+++ b/packages/codelift/components/CSSInspector/index.tsx
@@ -33,10 +33,9 @@ export const CSSInspector: FunctionComponent = observer(() => {
       <InputGroup>
         <Input
           autoFocus
-          bg="gray.600"
+          bg="white"
           boxShadow="md"
-          className="text-black shadow-md bg-gray-200 focus:bg-white border-transparent focus:border-blue-light p-2 static w-full"
-          color="white"
+          color="black"
           onChange={(event: ChangeEvent) =>
             store.search((event.target as HTMLInputElement).value)
           }

--- a/packages/codelift/components/Selector/index.tsx
+++ b/packages/codelift/components/Selector/index.tsx
@@ -1,101 +1,104 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
+import { Instance } from "mobx-state-tree";
 import { createPortal } from "react-dom";
 
 import { observer, useStore } from "../Store";
+import { Node } from "../Store/Node";
 
-export const Selector: FunctionComponent = observer(() => {
-  const store = useStore();
-  const [isHovering, setIsHovering] = useState(false);
+type SelectorProps = {
+  node: Instance<typeof Node>;
+};
 
-  useEffect(() => {
-    const { root } = store;
+export const Selector: FunctionComponent<SelectorProps> = observer(
+  ({ node }) => {
+    const store = useStore();
+    const [isHovering, setIsHovering] = useState(false);
 
-    if (!root) {
-      return;
+    useEffect(() => {
+      const { root } = store;
+
+      if (!root) {
+        return;
+      }
+
+      const handleClick = (event: MouseEvent) => {
+        event.preventDefault();
+        store.handleTargetSelect(event.target as HTMLElement);
+      };
+
+      const handleHover = (event: MouseEvent) => {
+        setIsHovering(event.target === node.element);
+        store.handleTargetHover(event.target as HTMLElement);
+      };
+
+      root.addEventListener("mousemove", handleHover);
+      root.addEventListener("click", handleClick);
+
+      return () => {
+        root.removeEventListener("click", handleClick);
+        root.removeEventListener("mousemove", handleHover);
+      };
+    }, [store.root]);
+
+    if (!store.contentWindow || !store.document || !node.element) {
+      return null;
     }
 
-    const handleClick = (event: MouseEvent) => {
-      event.preventDefault();
-      store.handleTargetSelect(event.target as HTMLElement);
-    };
+    const { top, right, bottom, left } = node.element.getBoundingClientRect();
 
-    const handleHover = (event: MouseEvent) => {
-      setIsHovering(event.target === store.target.element);
-      store.handleTargetHover(event.target as HTMLElement);
-    };
-
-    root.addEventListener("mousemove", handleHover);
-    root.addEventListener("click", handleClick);
-
-    return () => {
-      root.removeEventListener("click", handleClick);
-      root.removeEventListener("mousemove", handleHover);
-    };
-  }, [store.root]);
-
-  if (!store.contentWindow || !store.document || !store.target.element) {
-    return null;
-  }
-
-  const {
-    top,
-    right,
-    bottom,
-    left
-  } = store.target.element.getBoundingClientRect();
-
-  return createPortal(
-    <div
-      id="__codelift-selector"
-      style={{
-        border: "1px dashed #4299e1",
-        height: bottom - top,
-        left: left + store.contentWindow.scrollX,
-        opacity: store.target.isPreviewing ? 0 : 1,
-        pointerEvents: "none",
-        position: "absolute",
-        top: top + store.contentWindow.scrollY,
-        transition: "all 200ms ease-in-out",
-        width: right - left,
-        zIndex: 40
-      }}
-    >
-      <label
+    return createPortal(
+      <div
+        id="__codelift-selector"
         style={{
-          background: "#4299e1",
-          borderRadius: "4px 4px 0 0",
-          color: "#ffffff",
-          fontFamily:
-            'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-          fontSize: "12px",
-          marginLeft: "-1px",
-          marginTop: "-22px",
-          maxWidth: "100%",
-          overflow: "hidden",
+          border: "1px dashed #4299e1",
+          height: bottom - top,
+          left: left + store.contentWindow.scrollX,
+          opacity: node.isPreviewing ? 0 : 1,
+          pointerEvents: "none",
           position: "absolute",
-          padding: "2px 4px",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap"
+          top: top + store.contentWindow.scrollY,
+          transition: "all 200ms ease-in-out",
+          width: right - left,
+          zIndex: 40
         }}
       >
-        {store.target.element.tagName.toLowerCase()}
+        <label
+          style={{
+            background: "#4299e1",
+            borderRadius: "4px 4px 0 0",
+            color: "#ffffff",
+            fontFamily:
+              'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+            fontSize: "12px",
+            marginLeft: "-1px",
+            marginTop: "-22px",
+            maxWidth: "100%",
+            overflow: "hidden",
+            position: "absolute",
+            padding: "2px 4px",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap"
+          }}
+        >
+          {node.element.tagName.toLowerCase()}
 
-        <small style={{ color: "#bee3f8" }}>
-          {typeof store.target.element.className === "string"
-            ? `.${store.target.element.className.split(" ").join(".")}`
-            : null}
-        </small>
-      </label>
-      <div
-        style={{
-          background: "#ebf8ff",
-          height: "100%",
-          opacity: isHovering ? 0.5 : 0,
-          transition: "all 200ms ease-in-out",
-          width: "100%"
-        }}
-      />
-    </div>,
-    store.document.body
-  );
-});
+          <small style={{ color: "#bee3f8" }}>
+            {typeof node.element.className === "string"
+              ? `.${node.element.className.split(" ").join(".")}`
+              : null}
+          </small>
+        </label>
+        <div
+          style={{
+            background: "#ebf8ff",
+            height: "100%",
+            opacity: isHovering ? 0.5 : 0,
+            transition: "all 200ms ease-in-out",
+            width: "100%"
+          }}
+        />
+      </div>,
+      store.document.body
+    );
+  }
+);

--- a/packages/codelift/components/Store/Node.ts
+++ b/packages/codelift/components/Store/Node.ts
@@ -4,10 +4,9 @@ import { TailwindRule } from "./TailwindRule";
 
 type Rule = Instance<typeof TailwindRule>;
 
-export const Target = types
-  .model("Target", {
+export const Node = types
+  .model("Node", {
     classNames: types.array(types.string),
-    isLocked: false,
     isPreviewing: false
   })
   .volatile(self => ({
@@ -101,12 +100,8 @@ export const Target = types
       self.isPreviewing = false;
     },
 
-    lock() {
-      self.isLocked = true;
-    },
-
     previewRule(rule: Rule) {
-      if (self.element && self.isLocked) {
+      if (self.element) {
         if (self.hasRule(rule)) {
           self.element.classList.remove(rule.className);
         } else {
@@ -122,12 +117,7 @@ export const Target = types
       self.element = element;
     },
 
-    unlock() {
-      self.isLocked = false;
-    },
-
     unset() {
       self.element = null;
-      self.isLocked = false;
     }
   }));

--- a/packages/codelift/components/Store/TailwindRule.ts
+++ b/packages/codelift/components/Store/TailwindRule.ts
@@ -2,6 +2,8 @@ import { getRoot, types } from "mobx-state-tree";
 
 import { classNameGroups } from "./classNameGroups";
 
+// TODO This isn't really tailwind-specific anymore, besides classNameGroups.
+// Actually, those groups should be created based on their properties.
 export const TailwindRule = types
   .model("TailwindRule", {
     cssText: types.string,

--- a/packages/codelift/components/Store/Target.ts
+++ b/packages/codelift/components/Store/Target.ts
@@ -120,8 +120,6 @@ export const Target = types
     set(element: HTMLElement) {
       self.classNames.replace([...element.classList]);
       self.element = element;
-
-      console.log(self.selector);
     },
 
     unlock() {

--- a/packages/codelift/components/TreeInspector/TreeList.tsx
+++ b/packages/codelift/components/TreeInspector/TreeList.tsx
@@ -15,16 +15,15 @@ export const TreeList: FunctionComponent<TreeListProps> = observer(
     const children = [...root.children] as HTMLElement[];
     const tagName = root.tagName.toLowerCase();
     const id = root.getAttribute("id");
-    const handleClick = useCallback(() => store.handleTargetSelect(root), [
-      root
-    ]);
+    const handleClick = useCallback(() => store.selected.set(root), [root]);
     const handleMouseEnter = useCallback(
       (event: MouseEvent) => {
         root.scrollIntoView({
           behavior: "smooth",
           block: "center"
         });
-        store.handleTargetHover(root);
+
+        store.target.set(root);
       },
       [root]
     );
@@ -57,7 +56,13 @@ export const TreeList: FunctionComponent<TreeListProps> = observer(
             height="1.5rem"
             rounded="0"
             size="sm"
-            variant={store.target.element === root ? "solid" : "ghost"}
+            variant={
+              store.selected.element === root
+                ? "outline"
+                : store.target.element === root
+                ? "solid"
+                : "ghost"
+            }
             verticalAlign="text-bottom"
           >
             <Text>{tagName}</Text>

--- a/packages/codelift/components/TreeInspector/index.tsx
+++ b/packages/codelift/components/TreeInspector/index.tsx
@@ -5,14 +5,19 @@ import {
   InputGroup,
   InputRightElement
 } from "@chakra-ui/core";
-import { FunctionComponent, useState, ChangeEvent } from "react";
+import { ChangeEvent, FunctionComponent, useCallback, useState } from "react";
 
 import { observer, useStore } from "../Store";
 
+import { Selector } from "../Selector";
 import { TreeList } from "./TreeList";
 
 export const TreeInspector: FunctionComponent = observer(() => {
   const store = useStore();
+
+  const handleMouseLeave = useCallback(() => {
+    store.target.unset();
+  }, [store.root]);
 
   if (!store.root) {
     return null;
@@ -20,6 +25,8 @@ export const TreeInspector: FunctionComponent = observer(() => {
 
   return (
     <>
+      {store.isOpen && <Selector node={store.target} />}
+
       {/* TODO Re-enable and filter through Node models  */}
       {/* e..g node.matchesFilter(filter), node.childrenMatchesFilter(filter) */}
       {/* <InputGroup>
@@ -34,7 +41,13 @@ export const TreeInspector: FunctionComponent = observer(() => {
         </InputRightElement>
       </InputGroup> */}
 
-      <Box paddingY="2" height="100%" overflow="auto" width="100%">
+      <Box
+        paddingY="2"
+        height="100%"
+        onMouseLeave={handleMouseLeave}
+        overflow="auto"
+        width="100%"
+      >
         <TreeList root={store.root} />
       </Box>
     </>


### PR DESCRIPTION
For the `TreeInspector`:

- Hovering should change the `targeted.element`, while
- Clicking should change the `selected.element`.

The `CSSInspector` should only show the styles for the `selected`.

(There doesn't need to be a hover over an element, unless there's a specific button on the left nav to target something via an icon)