### PR TITLE
Pass url as true to `open` to allow encoding

### DIFF
--- a/packages/codelift/server.js
+++ b/packages/codelift/server.js
@@ -41,7 +41,7 @@ app
       const url = `http://localhost:${PORT}`;
 
       console.log(`☁️  codelift started on ${url}`);
-      open(url);
+      open(url, { url: true });
     });
   })
   .catch(error => {


### PR DESCRIPTION
Fixes #53 
I don't use Windows much but reading from `open` [docs](https://www.npmjs.com/package/open#url), it feels like this could technically fix issues with Windows.

Also, `create-react-app` passes the same option [here](https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/openBrowser.js#L107)

@ericclemmons @dance2die Thoughts? 