### PR TITLE
DevTools' inspect(element)

### DIFF
--- a/packages/codelift/components/StyleInspector/index.tsx
+++ b/packages/codelift/components/StyleInspector/index.tsx
@@ -1,5 +1,5 @@
 import { capitalize, words } from "lodash";
-import { ComponentType, FunctionComponent } from "react";
+import { ComponentType, FunctionComponent, useEffect } from "react";
 import {
   AlignCenter,
   AlignLeft,
@@ -65,6 +65,15 @@ const Heading: FunctionComponent<HeadingProps> = ({ children, Icon }) => (
 // TODO Move hover: highlight to <li>
 export const StyleInspector: FunctionComponent = observer(() => {
   const store = useStore();
+
+  useEffect(() => {
+    console.info(
+      "%ccode%clift",
+      "color: #669",
+      "font-style: italic; font-size: 0.8em; top: -.5em;",
+      store.selected?.element?.element
+    );
+  }, [store.selected?.element]);
 
   // TODO Add a toggle for :hover,, :focus, :active based on selectorText
   return (


### PR DESCRIPTION
Once #64 lands, it'd be nice if the menu could have a "Target in DevTools" which calls `inspect(element)`.

From what I can tell, it _may_ not be available on the page, but only to dev tools.

If that doesn't work, it may be possible to gate an action with `debugger` that has some code/comment/something to tell the user how to click to activate it:
> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger