### PR TITLE
Update CRA to use register + inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Within your project:
 
    _(`codelift` runs `yarn ____` with whatever you provide)_
 
-1. Add the following `import "codelift/register"` to the top of your `src/App.tsx` or `pages/_app.tsx`:
+1. Add the following `import "codelift/register"` to the top of your `src/index.tsx` or `pages/_app.tsx`:
 
    ```js
    import React from "react";

--- a/examples/cra/src/App.tsx
+++ b/examples/cra/src/App.tsx
@@ -1,4 +1,3 @@
-import "codelift/register";
 import React from "react";
 import logo from "./logo.svg";
 import "./App.css";

--- a/examples/cra/src/App.tsx
+++ b/examples/cra/src/App.tsx
@@ -4,6 +4,8 @@ import "./App.css";
 
 import "tailwindcss/dist/tailwind.css";
 
+import { Link } from "./Link";
+
 const App: React.FC = () => {
   return (
     <div className="App">
@@ -12,14 +14,7 @@ const App: React.FC = () => {
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+        <Link>Learn React</Link>
       </header>
     </div>
   );

--- a/examples/cra/src/Link.tsx
+++ b/examples/cra/src/Link.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from "react";
+
+export const Link: FunctionComponent = ({ children }) => (
+  <a
+    className="App-link"
+    href="https://reactjs.org"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {children}
+  </a>
+);
+
+// @ts-ignore
+Link.Inspector = ({ props, setProps }) => {
+  return (
+    <label className="flex flex-col px-4">
+      <small className="opacity-75 italic tracking-wider">Text</small>
+      <input
+        autoFocus
+        className="bg-transparent border-b border-dotted"
+        onChange={event => setProps({ children: event.target.value })}
+        defaultValue={props.children}
+      />
+    </label>
+  );
+};

--- a/examples/cra/src/index.tsx
+++ b/examples/cra/src/index.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+import { register } from "codelift";
+register({ React, ReactDOM });
+
+ReactDOM.render(<App />, document.getElementById("root"));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/packages/codelift/README.md
+++ b/packages/codelift/README.md
@@ -1,16 +1,36 @@
 # code<sup>_lift_</sup>
 
-![Create React App Example](/codelift.next.gif)
-
 > A "No Code" GUI for your existing React app.
+>
+> ![Next.js Example](/screenshot.png)
+> – [Launch Tweet](https://twitter.com/ericclemmons/status/1205161643300098048)
 
 ## Getting Started
 
-Within your [create-react-app][cra] project:
+Within your project:
 
 1. `yarn add codelift --dev`
-1. `yarn codelift start`
-1. Add `import "codelift/register"` to the top of your `src/App.tsx`.
+1. For [create-react-app][cra]:
+
+   `yarn codelift start`
+
+   For [Next.js][next]:
+
+   `yarn codelift dev`
+
+   _(`codelift` runs `yarn ____` with whatever you provide)_
+
+1. Add the following `import "codelift/register"` to the top of your `src/index.tsx` or `pages/_app.tsx`:
+
+   ```js
+   import React from "react";
+   import ReactDOM from "react-dom";
+
+   import { register } from "codelift";
+   register({ React, ReactDOM });
+   ```
+
+   _`codelift` requires access to your application's copy of `react` and `react-dom` to support custom inspectors._
 
 ## Examples
 
@@ -19,21 +39,45 @@ Within your [create-react-app][cra] project:
 
 ## Features
 
-### CSS Inspector
+- <kbd>Double-Click</kbd> componetns & elements in the tree view to open in VS Code.
 
-1. Hover & Select an element.
-1. **Find-as-you-type** CSS classes.
-1. **Hover to preview** before applying.
-1. **Click to toggle** in your source code.
+- [Tailwind](https://tailwindcss.com/) Visual Inspector
 
-### Feature Requests
+  1. Hover & Select an element.
+  1. **Find-as-you-type** CSS classes.
+  1. **Hover to preview** before applying.
+  1. **Click to toggle** in your source code.
 
-- [ ] Install missing dependencies
-- [ ] Click tag to open in editor
-- [ ] Add/Wrap elements
-- [ ] Convert element to Component
-- [ ] `:hover`, etc. classes
-- [New Feature Request](https://github.com/ericclemmons/codelift/issues/new)
+- <kbd>CMD+'</kbd> to toggle _codelift_ and browse normally.
+
+- Custom Inspectors:
+
+  Suppose you have [`Header` component](examples/next/components/Header.tsx) that accepts a `title`:
+
+  ```js
+  export const Header = ({ title }) => {
+    ...
+  }
+  ```
+
+  Next, attach a custom `Inspector` component to your `Header` that accepts the current `props` and calls `setProps` when it changes:
+
+  ```js
+  Header.Inspector = ({ props, setProps }) => {
+    return (
+      <input
+        onChange={event => setProps({ title: event.target.value })}
+        defaultValue={props.title}
+      />
+    );
+  };
+  ```
+
+  Your `Inspector` will be rendered in a sidepanel when a `Header` is selected:
+
+  > ![Header Inspector](/header.inspector.png)
+
+* [What feature would you like to see?](https://github.com/ericclemmons/codelift/issues/new)
 
 ## Contributing
 
@@ -45,4 +89,26 @@ Within your [create-react-app][cra] project:
 - Eric Clemmons
 
 [cra]: https://github.com/facebook/create-react-app
+[next]: https://github.com/zeit/next.js/
 [tailwind]: https://tailwindcss.com/
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://ericclemmons.com/"><img src="https://avatars0.githubusercontent.com/u/15182?v=4" width="50px;" alt=""/><br /><sub><b>Eric Clemmons</b></sub></a><br /><a href="https://github.com/ericclemmons/codelift/commits?author=ericclemmons" title="Code">💻</a> <a href="https://github.com/ericclemmons/codelift/commits?author=ericclemmons" title="Documentation">📖</a> <a href="#infra-ericclemmons" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
+    <td align="center"><a href="https://aulisi.us"><img src="https://avatars2.githubusercontent.com/u/6629172?v=4" width="50px;" alt=""/><br /><sub><b>​Faizaan</b></sub></a><br /><a href="https://github.com/ericclemmons/codelift/commits?author=aulisius" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/packages/codelift/index.d.ts
+++ b/packages/codelift/index.d.ts
@@ -1,0 +1,1 @@
+declare module "codelift";


### PR DESCRIPTION
With #70, CRA wasn't updated.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.94.8ec9dff.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install codelift@1.0.1-canary.94.8ec9dff.0
  # or 
  yarn add codelift@1.0.1-canary.94.8ec9dff.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
