### PR TITLE
useInspector API

### DIFF
--- a/examples/next/components/Header.tsx
+++ b/examples/next/components/Header.tsx
@@ -1,3 +1,4 @@
+import { useInspector } from "codelift";
 import { useRouter } from "next/router";
 import { FunctionComponent } from "react";
 
@@ -5,14 +6,32 @@ const greetings = ["hello", "saluton", "hei", "bonjour", "guten tag", "aloha"];
 
 type HeaderProps = { title: string };
 
-export const Header: FunctionComponent<HeaderProps> = ({ title }) => {
+const HeaderInspector = ({ props, setProps }) => {
+  return (
+    <label className="flex flex-col px-4">
+      <small className="opacity-75 italic tracking-wider">Title</small>
+      <input
+        autoFocus
+        className="bg-transparent border-b border-dotted"
+        onChange={(event) => setProps({ title: event.target.value })}
+        defaultValue={props.title}
+      />
+    </label>
+  );
+};
+
+export const Header: FunctionComponent<HeaderProps> = (props) => {
+  const [ref, { title }] = useInspector(props, HeaderInspector);
   const router = useRouter();
   const { path = [] } = router.query;
   const [greeting] = path as string[];
   const next = greetings[(greetings.indexOf(greeting) + 1) % greetings.length];
 
   return (
-    <div className="bg-black text-white text-center text-5xl shadow-lg py-12">
+    <div
+      className="bg-black text-white text-center text-5xl shadow-lg py-12"
+      ref={ref}
+    >
       <h1 className="tracking-wider">
         <a href={`/${next}`}>
           {greeting && (
@@ -22,19 +41,5 @@ export const Header: FunctionComponent<HeaderProps> = ({ title }) => {
         </a>
       </h1>
     </div>
-  );
-};
-
-Header["Inspector"] = ({ props, setProps }) => {
-  return (
-    <label className="flex flex-col px-4">
-      <small className="opacity-75 italic tracking-wider">Title</small>
-      <input
-        autoFocus
-        className="bg-transparent border-b border-dotted"
-        onChange={event => setProps({ title: event.target.value })}
-        value={props.title}
-      />
-    </label>
   );
 };

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^2.1.0",
+    "@types/react": "^16.9.32",
     "codelift": "^1.0.10",
     "postcss-preset-env": "^6.7.0",
     "tailwindcss": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,17 @@
     "release": "auto shipit",
     "test": "echo No Tests"
   },
-  "workspaces": [
-    "examples/*",
-    "packages/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "examples/*",
+      "packages/*"
+    ],
+    "nohoist": [
+      "**/next",
+      "**/react",
+      "**/react-dom"
+    ]
+  },
   "devDependencies": {
     "@auto-it/all-contributors": "^9.26.0",
     "@auto-it/first-time-contributor": "^9.26.0",

--- a/packages/codelift/components/ComponentInspector/index.tsx
+++ b/packages/codelift/components/ComponentInspector/index.tsx
@@ -22,51 +22,12 @@ export const ComponentInspector = observer(() => {
       ReactDOM.render(
         React.createElement(Inspector, {
           props,
-          setProps: selected.previewProps
+          setProps: selected.previewProps,
         }),
         ref.current
       );
     },
     [ref.current, props, Inspector]
-  );
-
-  useEffect(
-    function renderPreview() {
-      if (!Inspector || !selected) {
-        return;
-      }
-
-      // Use host's React/ReactDOM from register
-      const { React, ReactDOM } = store.contentWindow as any;
-
-      // Wrap preview in a <span> (just in case there are any fragments)
-      let preview = React.createElement(
-        "span",
-        {},
-        React.createElement(type, props)
-      );
-
-      // Wrap preview in contexts
-      selected.contexts.forEach(context => {
-        const { value } = context.instance.memoizedProps;
-        preview = React.createElement(
-          context.instance.type,
-          { value },
-          preview
-        );
-      });
-
-      // ! Find first HostComponent's stateNode, as `instance.child` can be a FunctionComponent or other ReactFiber type that's not associated with the DOM
-      const node = selected.instance.child.stateNode;
-
-      //  This will render the preview _within_ the current DOM node.
-      // ! Warning: render(...): Replacing React-rendered children with a new root component. If you intended to update the children of this node, you should instead have the existing children update their state and render the new components instead of calling ReactDOM.render.
-      ReactDOM.render(preview, node);
-      // We don't want the nesting, so we replace the node with the <span> from before
-      // ! Warning: render(...): It looks like the React-rendered content of this container was removed without using React. This is not supported and will cause errors. Instead, call ReactDOM.unmountComponentAtNode to empty a container.
-      node.replaceWith(node.firstChild);
-    },
-    [props]
   );
 
   if (!Inspector && store.selected?.isUserCode) {

--- a/packages/codelift/index.js
+++ b/packages/codelift/index.js
@@ -1,5 +1,8 @@
 const isDev =
   process.env.NODE_ENV === "development" && typeof window === "object";
-const noop = arg => arg;
 
-module.exports.register = isDev ? require("./register") : noop;
+module.exports.register = isDev ? require("./register") : (arg) => arg;
+
+module.exports.useInspector = isDev
+  ? require("./useInspector")
+  : (props) => [null /* ref */, props];

--- a/packages/codelift/models/App/index.ts
+++ b/packages/codelift/models/App/index.ts
@@ -5,11 +5,12 @@ import { SyntheticEvent } from "react";
 import { createRulesFromDocument, CSSRule, ICSSRule } from "../CSSRule";
 import {
   createReactNode,
-  getReactInstance,
   IReactNode,
   ReactNode,
-  flattenReactNodes
+  flattenReactNodes,
 } from "../ReactNode";
+
+import { getReactInstance } from "../../utils/getReactInstance";
 
 export interface IApp extends Instance<typeof App> {}
 
@@ -28,18 +29,18 @@ export const App = types
     ),
     targeted: types.maybe(types.safeReference(ReactNode)),
     selected: types.maybe(types.safeReference(ReactNode)),
-    selector: types.maybe(types.string)
+    selector: types.maybe(types.string),
   })
-  .volatile(self => ({
+  .volatile((self) => ({
     // Needed for scrollX/Y
     contentWindow: null as null | Window,
     // Needed for document.body
     document: null as null | HTMLDocument,
     // In-case of an error accessing the iframe
     error: null as null | Error,
-    rule: null as null | ICSSRule
+    rule: null as null | ICSSRule,
   }))
-  .views(self => ({
+  .views((self) => ({
     get appliedCSSRules(): ICSSRule[] {
       const { selected } = self;
 
@@ -93,7 +94,7 @@ export const App = types
     },
 
     findReactNodeByElement(element: HTMLElement) {
-      const reactNode = self.reactNodes.find(reactNode => {
+      const reactNode = self.reactNodes.find((reactNode) => {
         return (
           reactNode &&
           reactNode.element &&
@@ -109,7 +110,7 @@ export const App = types
 
       const words = query
         .split(" ")
-        .map(word => word.trim())
+        .map((word) => word.trim())
         .filter(Boolean);
 
       const matching = words.reduce(
@@ -121,25 +122,25 @@ export const App = types
 
             (rule: ICSSRule) => {
               return rule.cssText.includes(word);
-            }
+            },
           ];
 
-          return filtered.filter(rule => tests.some(test => test(rule)));
+          return filtered.filter((rule) => tests.some((test) => test(rule)));
         },
         [...cssRules]
           // Remove duplicates
           // .filter(match => !this.appliedRules.includes(match))
           // Remove :hover, :active, etc.
-          .filter(match => match.className.indexOf(":") === -1)
+          .filter((match) => match.className.indexOf(":") === -1)
       );
 
       return sortBy(matching, [
-        ...words.map(word => (rule: ICSSRule) => {
+        ...words.map((word) => (rule: ICSSRule) => {
           return rule.className.startsWith(word) ? -1 : 0;
         }),
         (rule: ICSSRule) => {
           return rule.className.replace(/[\d+]/g, "");
-        }
+        },
       ]);
     },
 
@@ -169,9 +170,9 @@ export const App = types
       console.error(`codelift could not find React's root container`);
 
       return null;
-    }
+    },
   }))
-  .actions(self => ({
+  .actions((self) => ({
     clearSelected() {
       self.selected = undefined;
     },
@@ -304,7 +305,7 @@ export const App = types
       const { selector } = self;
 
       if (self.root && selector) {
-        self.selected = self.reactNodes.find(reactNode => {
+        self.selected = self.reactNodes.find((reactNode) => {
           return (
             reactNode &&
             reactNode.element &&
@@ -362,5 +363,5 @@ export const App = types
 
     targetReactNode(node: IReactNode) {
       self.targeted = node;
-    }
+    },
   }));

--- a/packages/codelift/models/ElementNode/index.ts
+++ b/packages/codelift/models/ElementNode/index.ts
@@ -3,34 +3,21 @@ import { getRoot, IAnyModelType, Instance, types } from "mobx-state-tree";
 
 import { CSSRule, ICSSRule } from "../CSSRule";
 import { IApp } from "../App";
+import { getReactInstance } from "../../utils/getReactInstance";
 
 export interface IElementNode extends Instance<typeof ElementNode> {}
-
-export const getReactInstance = (element: HTMLElement) => {
-  if ("_reactRootContainer" in element) {
-    // @ts-ignore Property '_reactRootContainer' does not exist on type 'never'.ts(2339)
-    return element._reactRootContainer._internalRoot.current.child;
-  }
-
-  for (const key in element) {
-    if (key.startsWith("__reactInternalInstance$")) {
-      // @ts-ignore No index signature with a parameter of type 'string' was found on type 'HTMLElement'.ts(7053)
-      return element[key];
-    }
-  }
-};
 
 export const ElementNode = types
   .model("ElementNode", {
     classNames: types.array(types.string),
     childNodes: types.array(types.late((): IAnyModelType => ElementNode)),
     previewedRule: types.maybeNull(types.safeReference(CSSRule)),
-    uuid: types.optional(types.identifierNumber, () => Math.random())
+    uuid: types.optional(types.identifierNumber, () => Math.random()),
   })
-  .volatile(self => ({
-    element: document.createElement("null")
+  .volatile((self) => ({
+    element: document.createElement("null"),
   }))
-  .views(self => ({
+  .views((self) => ({
     get className() {
       const classNames = new Set(self.classNames);
 
@@ -45,7 +32,7 @@ export const ElementNode = types
       // Remove overlapping classes that style the same properties
       // ! This is O(n) and potentially slow.
       // !Instead, we need a map of cssRulesByClassName, cssRulesByKeys
-      this.store.cssRules.forEach(rule => {
+      this.store.cssRules.forEach((rule) => {
         const sameStyles = hashStyles(rule.style) === previewHash;
 
         if (sameStyles && classNames.has(rule.className)) {
@@ -109,7 +96,7 @@ export const ElementNode = types
       while (element) {
         const nthChild = element.parentNode
           ? [...element.parentNode.childNodes]
-              .filter(node => node.nodeType === 1)
+              .filter((node) => node.nodeType === 1)
               .indexOf(element) + 1
           : null;
         const { id, tagName } = element;
@@ -118,7 +105,7 @@ export const ElementNode = types
           [
             tagName.toLowerCase(),
             id && `#${element.id}`,
-            !id && nthChild && `:nth-child(${nthChild})`
+            !id && nthChild && `:nth-child(${nthChild})`,
           ]
             .filter(Boolean)
             .join("")
@@ -136,9 +123,9 @@ export const ElementNode = types
 
     get tagName() {
       return self.element.tagName.toLowerCase();
-    }
+    },
   }))
-  .actions(self => ({
+  .actions((self) => ({
     afterCreate() {
       autorun(() => {
         // Keep element className in sync with computed (preview) one
@@ -159,7 +146,7 @@ export const ElementNode = types
 
       self.classNames.replace([...element.classList]);
       self.childNodes.replace(createChildNodes(element));
-    }
+    },
   }));
 
 export const createNode = (element: HTMLElement) => {

--- a/packages/codelift/models/ReactNode/index.tsx
+++ b/packages/codelift/models/ReactNode/index.tsx
@@ -4,7 +4,7 @@ import {
   hasParentOfType,
   IAnyModelType,
   Instance,
-  types
+  types,
 } from "mobx-state-tree";
 
 import { IApp } from "../App";
@@ -20,13 +20,13 @@ export const ReactNode = types
   .model("ReactNode", {
     children: types.array(types.late((): IAnyModelType => ReactNode)),
     element: types.maybe(ElementNode),
-    uuid: types.optional(types.identifierNumber, () => Math.random())
+    uuid: types.optional(types.identifierNumber, () => Math.random()),
   })
-  .volatile(self => ({
+  .volatile((self) => ({
     instance: null as any,
-    props: {} as any
+    props: {} as any,
   }))
-  .views(self => ({
+  .views((self) => ({
     get contexts() {
       const contexts: IReactNode[] = [];
       let parent = self as IReactNode;
@@ -51,7 +51,7 @@ export const ReactNode = types
         Object.keys(this.originalProps).length ===
           Object.keys(self.props).length &&
         Object.keys(this.originalProps).every(
-          key =>
+          (key) =>
             self.props.hasOwnProperty(key) &&
             this.originalProps[key] === self.props[key]
         );
@@ -107,9 +107,9 @@ export const ReactNode = types
 
     get store(): IApp {
       return getRoot(self);
-    }
+    },
   }))
-  .actions(self => ({
+  .actions((self) => ({
     resetProps() {
       self.props = self.originalProps;
     },
@@ -126,7 +126,7 @@ export const ReactNode = types
 
       fetch("/api", {
         method: "POST",
-        body: JSON.stringify({ query, variables })
+        body: JSON.stringify({ query, variables }),
       });
     },
 
@@ -151,7 +151,7 @@ export const ReactNode = types
       }
 
       self.props = self.originalProps;
-    }
+    },
   }));
 
 export const createReactNode = (instance: any) => {
@@ -168,18 +168,4 @@ export const flattenReactNodes = (nodes: IReactNode[]) => {
 
     return acc;
   }, [] as IReactNode[]);
-};
-
-export const getReactInstance = (element: HTMLElement) => {
-  if ("_reactRootContainer" in element) {
-    // @ts-ignore Property '_reactRootContainer' does not exist on type 'never'.ts(2339)
-    return element._reactRootContainer._internalRoot.current.child;
-  }
-
-  for (const key in element) {
-    if (key.startsWith("__reactInternalInstance$")) {
-      // @ts-ignore No index signature with a parameter of type 'string' was found on type 'HTMLElement'.ts(7053)
-      return element[key];
-    }
-  }
 };

--- a/packages/codelift/useInspector.js
+++ b/packages/codelift/useInspector.js
@@ -1,0 +1,38 @@
+const { getReactInstance } = require("./utils/getReactInstance");
+
+module.exports = function useInspector(props, Inspector) {
+  const { React } = window;
+
+  if (!React) {
+    throw new Error(
+      "React was not registered.  Did you add `register({ React, ReactDOM });` to the top of your application?"
+    );
+  }
+
+  const { useCallback, useState } = React;
+  const [previewedProps, previewProps] = useState(props);
+
+  const ref = useCallback(
+    (node) => {
+      if (!node) {
+        return;
+      }
+
+      const { type } = getReactInstance(node)._debugOwner;
+
+      type.Inspector = ({ props, setProps }) => {
+        return React.createElement(Inspector, {
+          props,
+          // setProps for codelift and for the original component
+          setProps(newProps) {
+            setProps(newProps);
+            previewProps(newProps);
+          },
+        });
+      };
+    },
+    [props, Inspector]
+  );
+
+  return [ref, previewedProps];
+};

--- a/packages/codelift/utils/getReactInstance.js
+++ b/packages/codelift/utils/getReactInstance.js
@@ -1,4 +1,4 @@
-export const getReactInstance = (element: HTMLElement) => {
+module.exports.getReactInstance = (element) => {
   if ("_reactRootContainer" in element) {
     // @ts-ignore Property '_reactRootContainer' does not exist on type 'never'.ts(2339)
     return element._reactRootContainer._internalRoot.current.child;

--- a/packages/codelift/utils/getReactInstance.ts
+++ b/packages/codelift/utils/getReactInstance.ts
@@ -1,0 +1,13 @@
+export const getReactInstance = (element: HTMLElement) => {
+  if ("_reactRootContainer" in element) {
+    // @ts-ignore Property '_reactRootContainer' does not exist on type 'never'.ts(2339)
+    return element._reactRootContainer._internalRoot.current.child;
+  }
+
+  for (const key in element) {
+    if (key.startsWith("__reactInternalInstance$")) {
+      // @ts-ignore No index signature with a parameter of type 'string' was found on type 'HTMLElement'.ts(7053)
+      return element[key];
+    }
+  }
+};


### PR DESCRIPTION
What I don't like about the current API:

- Requires registering `React` and `ReactDOM` so I can render previews _over_ your component.
- **Does not** leverage React's own reconciler, but creates warnings for rendering into your DOM.
- Does not having typing for `Component.Inspector` (yet).

#### Current API

```jsx
const Header = ({ title }) => {
  return <h1>{title}</h1>
}

Header.Inspector = ({ props, setProps }) => ...
```

#### Proposed API

```jsx
const Header = (props) => {
  const { title } = useInspector(props, HeaderInspector?)

  return <h1>{title}</h1>
}
```

---

- This avoids HoCs, which break `Component.name` and create a noisy tree.
- Can still be tree-shaken, as prod-mode will be a noop.
- Re-renders using _your_ React instance's reconciler.
- Optional inspector, since introspection may be possible via TypeScript.
- `useInspector` _may_ need access to `React` so it can use your app's copy of `useState` or other hooks.